### PR TITLE
Change the part that tells people to use Purchase Date not Validated

### DIFF
--- a/server/advanced/macos-virtualization/running-a-macos-vm/enabling-imessage-in-a-vm.md
+++ b/server/advanced/macos-virtualization/running-a-macos-vm/enabling-imessage-in-a-vm.md
@@ -33,8 +33,7 @@ If you would like to use a _lower_ macOS version than Catalina, you will need to
 
 1. Follow the OpenCore guide linked above, but only complete the following sections (make sure to save all information from these sections for later use):
    * **Using GenSMBIOS**
-     * You will want to use the model number `MacPro7,1`. Verify your serial numbers using the [Apple Check Coverage Page.](https://checkcoverage.apple.com/) You have got a good serial number when the page says **Purchase Date not Validated**.
-       * We recommend to use a browser with TOR functionality for this step, such as Brave Browser (use "New private window with Tor" option). This is so Apple does not rate limit you when checking serials (TOR randomizes your IP address and location every time you load the page, at the cost of network speed).
+     * You will want to use the model number `MacPro7,1`. Verify your serial numbers using the [Apple Check Coverage Page.](https://checkcoverage.apple.com/) You have got a good serial number when the page highlights the entry box in red and says **Please enter a valid serial number.**.  As long as it was correctly copied from GenSMBIOS you should be good to go.
    * **Choose a Mac Address**
    * **Derive the corresponding ROM Value**
 2. Open up a Notepad window, and type the following information (you will need this later):\


### PR DESCRIPTION
According to OpenCore, it is not recommended to use Purchase Date not Validated serials as they cause conflicts with existing Macs.  We had one instance today where I believe this happened to someone in the Discord.  It would appear as if someone used Purchase Date not Validated serial (perhaps the owner of the connected Mac) to activate Beeper.  [Discord convo](https://discord.com/channels/640229510662455326/782690923640782878/1197726455732383784)  This is directly from the Fixing iMessage and other services with OpenCore guide:
![image](https://github.com/BlueBubblesApp/bluebubbles-docs/assets/60277022/6e148d41-9247-4841-b46e-74ada2c192b6)
The only downside with using the invalid serial is that it pretty much guarantees a conversation with Apple, but at least you won't risk getting locked out by the real owner of the device with that serial.  I've talked with Apple, they get it sorted out and you end up with your own unique Purchase Date not Validated serial!