### PR TITLE
Fix cerbot renewal instructions

### DIFF
--- a/server/advanced/generating-an-ssl-certificate-using-certbot.md
+++ b/server/advanced/generating-an-ssl-certificate-using-certbot.md
@@ -58,10 +58,11 @@ By default, your certificate only lasts a set amount of time. In order to automa
    * `crontab -e`
 2. Hit the `i` key on your keyboard once
 3. Paste the following line into the text area in your Terminal:
-   * `0 0,12 * * * $(command -v python3) -c 'import random; import time; time.sleep(random.random() * 3600)' && $(command -v certbot) renew -q`
+   * `0 0,12 * * * /usr/local/bin/python3 -c 'import random; import time; time.sleep(random.random() * 3600)' && /usr/local/bin/certbot renew -q`
 4. Hit the `Escape` key, then type `:wq` and then hit `Enter`
 
-The `cron` configuration is now saved and your certificate will auto-renew
+The `cron` configuration is now saved and your certificate will auto-renew. To check that the renewal process is working, wait at least 12 hours, then check the certbot logs located at `~/certbot/logs/letsencrypt.log`. If you don't see any recent logs, then it's possible the paths in the crontab are not correct. Run the following command and verify the output matches the paths in the crontab entry.
+  * `echo "\nPython Path: $(command -v python3) \nCertbot Path: $(command -v certbot) \n"`
 
 ### Port-forwarding and Dynamic DNS setup
 

--- a/server/advanced/generating-an-ssl-certificate-using-certbot.md
+++ b/server/advanced/generating-an-ssl-certificate-using-certbot.md
@@ -58,7 +58,7 @@ By default, your certificate only lasts a set amount of time. In order to automa
    * `crontab -e`
 2. Hit the `i` key on your keyboard once
 3. Paste the following line into the text area in your Terminal:
-   * `0 0,12 * * * /usr/local/bin/python3 -c 'import random; import time; time.sleep(random.random() * 3600)' && /usr/local/bin/certbot renew -q`
+   * `0 0,12 * * * /usr/local/bin/python3 -c 'import random; import time; time.sleep(random.random() * 3600)' && /usr/local/bin/certbot renew -q --post-hook "killall BlueBubbles ; sleep 10 && open -a BlueBubbles"`
 4. Hit the `Escape` key, then type `:wq` and then hit `Enter`
 
 The `cron` configuration is now saved and your certificate will auto-renew. To check that the renewal process is working, wait at least 12 hours, then check the certbot logs located at `~/certbot/logs/letsencrypt.log`. If you don't see any recent logs, then it's possible the paths in the crontab are not correct. Run the following command and verify the output matches the paths in the crontab entry.


### PR DESCRIPTION
I noticed my cerbot renewals were not running from cron. It turns out that cron does not seems to have the same binaries in its `$PATH` that the standard user has. I've also added the ability to restart the BlueBubbles server when the renewal succeeds.

The official [certbot instructions](https://certbot.eff.org/instructions?ws=other&os=osx&tab=wildcard#:~:text=Set%20up%20automatic%20renewal) run the renewals as root and directly manipulate the root crontab without using `crontab -e` so their command: 

```shell
echo "0 0,12 * * * root $(command -v python3) -c 'import random; import time; time.sleep(random.random() * 3600)' && sudo $(command -v certbot) renew -q" | sudo tee -a /etc/crontab > /dev/null
```
will evaluate the `$(command -v certbot)` subshell command and insert the full path to `certbot`. 

I've updated the instructions to use the paths that should be there if they have used brew to install everything. Alternatively we could ask the reader to first run a command like: 

```shell
echo "\n--- COPY THE TEXT BELOW ---\n\n0 0,12 * * * $(command -v python3) -c 'import random; import time; time.sleep(random.random() * 3600)' && $(command -v certbot) renew -q\n\n"
```

And then copy-paste the output into the crontab editor. I figured this was a little too complicated as editing the crontab will take over their terminal and they won't be able to easily copy-paste the output from the previous command.