### PR TITLE
Update manual Firestore database setup

### DIFF
--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -35,14 +35,15 @@ The name of the project does not have to be **BlueBubblesApp** if you already ha
 {% endhint %}
 
 1. Click **Create a Project** and enter **BlueBubblesApp** as the name. Disable Google Analytics (why do you want Google spying on you?) and wait for the project to be created.
-2. Open the navigation menu and select **Databases** > **Firestore**. Depending on which console layout Google shows you, this may instead appear as **Build** > **Firestore Database**.
-3. Click **Create database**.
+2. Open the navigation menu and select **Databases & Storage** > **Firestore**. Depending on which console layout Google shows you, this may instead appear as **Build** > **Firestore Database**.
+3. Click **Create database**. If the project already has a Firestore database, this button is labeled **Add database** instead.
 4. On the **Create database** page:
-   * Leave the **Database ID** set to `(default)`.
-   * Select **Standard Edition**.
-   * Select **Firestore in Native mode**.
-   * Select **Restricted** security rules. You will update these rules in the next steps.
-   * Choose a region or multi-region close to the Mac running BlueBubbles, then click **Create Database**.
+   * Leave the **Database ID** set to `(default)`, if this option is shown.
+   * Select **Standard edition**, if this option is shown.
+   * Select **Firestore in Native mode**, if this option is shown.
+   * Choose a region or multi-region close to the Mac running BlueBubbles.
+   * Select **Production mode** for the starting security rules. You will replace these rules in the next steps.
+   * Click **Create**.
 5. If Cloud Firestore does not show the database page after creation, refresh the page.
 6. In the tabs near the top, click **Rules**.
 7. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.

--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -41,7 +41,7 @@ The name of the project does not have to be **BlueBubblesApp** if you already ha
    * Leave the **Database ID** set to `(default)`, if this option is shown.
    * Select **Standard edition**, if this option is shown.
    * Select **Firestore in Native mode**, if this option is shown.
-   * Choose a region or multi-region close to the Mac running BlueBubbles.
+   * Choose a region or multi-region close to the Mac running BlueBubbles. This location cannot be changed after the database is created, so review the selection before continuing.
    * Select **Production mode** for the starting security rules. You will replace these rules in the next steps.
    * Click **Create**.
 5. If Cloud Firestore does not show the database page after creation, refresh the page.

--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -35,16 +35,22 @@ The name of the project does not have to be **BlueBubblesApp** if you already ha
 {% endhint %}
 
 1. Click **Create a Project** and enter **BlueBubblesApp** as the name. Disable Google Analytics (why do you want Google spying on you?) and wait for the project to be created.
-2. In the tabs on the far left, click **Build** > **Firestore Database.**
-3. Next, **Create database** and press **Next > Enable.** You can change the database location if you are not based in North America so it is closer to you.
-4. If Cloud Firestore glitches and does not show you the database page, simply refresh the page.
-5. In the tabs near the top, click **Rules**
-6. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.
-7. Click the gear cog in the top left and click **Project Settings**.
-8. In the tabs near the top, navigate to **Service Accounts**. Generate a new private key and save this locally. **This will download file 1 / 2 needed for the manual setup.**
-9. Next, navigate to the **General** tab.
-10. Scroll to the bottom of the page and click the Android icon to add an Android app. Set the package name to `com.bluebubbles.messaging` and leave the other fields blank.
-11. Click **Register app**, then **Download google\_services.json**. **This will download file 2 / 2 needed for the manual setup.**
+2. Open the navigation menu and select **Databases** > **Firestore**. Depending on which console layout Google shows you, this may instead appear as **Build** > **Firestore Database**.
+3. Click **Create database**.
+4. On the **Create database** page:
+   * Leave the **Database ID** set to `(default)`.
+   * Select **Standard Edition**.
+   * Select **Firestore in Native mode**.
+   * Select **Restricted** security rules. You will update these rules in the next steps.
+   * Choose a region or multi-region close to the Mac running BlueBubbles, then click **Create Database**.
+5. If Cloud Firestore does not show the database page after creation, refresh the page.
+6. In the tabs near the top, click **Rules**.
+7. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.
+8. Click the gear cog in the top left and click **Project Settings**.
+9. In the tabs near the top, navigate to **Service Accounts**. Generate a new private key and save this locally. **This will download file 1 / 2 needed for the manual setup.**
+10. Next, navigate to the **General** tab.
+11. Scroll to the bottom of the page and click the Android icon to add an Android app. Set the package name to `com.bluebubbles.messaging` and leave the other fields blank.
+12. Click **Register app**, then **Download google\_services.json**. **This will download file 2 / 2 needed for the manual setup.**
 {% endtab %}
 
 {% tab title="Video Guide" %}

--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -36,22 +36,21 @@ The name of the project does not have to be **BlueBubblesApp** if you already ha
 
 1. Click **Create a Project** and enter **BlueBubblesApp** as the name. Disable Google Analytics (why do you want Google spying on you?) and wait for the project to be created.
 2. Open the navigation menu and select **Databases & Storage** > **Firestore**. Depending on which console layout Google shows you, this may instead appear as **Build** > **Firestore Database**.
-3. Click **Create database**. If the project already has a Firestore database, this button is labeled **Add database** instead.
-4. On the **Create database** page:
+3. Click **Create database**. If the project already has a Firestore database, this button is labeled **Add database** instead. On the **Create database** page:
    * Leave the **Database ID** set to `(default)`, if this option is shown.
    * Select **Standard edition**, if this option is shown.
    * Select **Firestore in Native mode**, if this option is shown.
    * Choose a region or multi-region close to the Mac running BlueBubbles. This location cannot be changed after the database is created, so review the selection before continuing.
    * Select **Production mode** for the starting security rules. You will replace these rules in the next steps.
    * Click **Create**.
-5. If Cloud Firestore does not show the database page after creation, refresh the page.
-6. In the tabs near the top, click **Rules**.
-7. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.
-8. Click the gear cog in the top left and click **Project Settings**.
-9. In the tabs near the top, navigate to **Service Accounts**. Generate a new private key and save this locally. **This will download file 1 / 2 needed for the manual setup.**
-10. Next, navigate to the **General** tab.
-11. Scroll to the bottom of the page and click the Android icon to add an Android app. Set the package name to `com.bluebubbles.messaging` and leave the other fields blank.
-12. Click **Register app**, then **Download google\_services.json**. **This will download file 2 / 2 needed for the manual setup.**
+4. If Cloud Firestore glitches and does not show you the database page, simply refresh the page.
+5. In the tabs near the top, click **Rules**
+6. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.
+7. Click the gear cog in the top left and click **Project Settings**.
+8. In the tabs near the top, navigate to **Service Accounts**. Generate a new private key and save this locally. **This will download file 1 / 2 needed for the manual setup.**
+9. Next, navigate to the **General** tab.
+10. Scroll to the bottom of the page and click the Android icon to add an Android app. Set the package name to `com.bluebubbles.messaging` and leave the other fields blank.
+11. Click **Register app**, then **Download google\_services.json**. **This will download file 2 / 2 needed for the manual setup.**
 {% endtab %}
 
 {% tab title="Video Guide" %}


### PR DESCRIPTION
## Summary

- update the manual setup guide for Google's current **Databases & Storage > Firestore** navigation
- retain the alternate **Build > Firestore Database** path for users who still see the Firebase layout
- document the required database ID, edition, mode, initial rules selection, and permanent location choice
- preserve the existing Rules step so the separate security-rules PR can merge independently

## Why

Google's current console no longer consistently matches the existing two-step **Create database > Next > Enable** instructions. The expanded flow prevents users from guessing which database edition and compatibility mode BlueBubbles expects.

Fixes BlueBubblesApp/bluebubbles-server#823.

## Scope

This PR updates the database-creation flow only. It does not change the later Firestore security-rule recommendation, which is addressed separately in BlueBubblesApp/bluebubbles-server#783 and docs PR #34.

## Validation

- walked through the current Firebase console flow read-only on July 23, 2026
- confirmed the current navigation, action labels, edition, database ID, mode, rules preset, and location wording
- ran `git diff --check origin/master...HEAD`
- simulated merging docs PRs #31 and #34 in both orders; both sequences merge without a conflict and pass `git diff --check`

No Firebase database was created and no account state changed. A screenshot is intentionally omitted because the vendor UI can drift; the text covers both observed navigation variants.
