### PR TITLE
Document webhook payloads and event keys

### DIFF
--- a/server/developer-guides/rest-api-and-webhooks.md
+++ b/server/developer-guides/rest-api-and-webhooks.md
@@ -125,6 +125,8 @@ Some events use a primitive value instead of an object. For example, `new-server
 
 ### Event keys
 
+The server's [`webhookEventOptions` constant](https://github.com/BlueBubblesApp/bluebubbles-server/blob/development/packages/server/src/server/api/http/constants.ts#L5) is the source of truth for available subscription keys. Compare this table with that constant whenever either list changes.
+
 | Event | Subscription key |
 | --- | --- |
 | All events | `*` |

--- a/server/developer-guides/rest-api-and-webhooks.md
+++ b/server/developer-guides/rest-api-and-webhooks.md
@@ -66,19 +66,94 @@ Or in the case of an error:
 
 ## Webhooks
 
-We support listening to the following events:
+When a subscribed event occurs, the server sends an HTTP `POST` request to the webhook URL with a `Content-Type` of `application/json`.
 
-1. New Messages
-2. Message Updates (delivered, read, etc)
-3. Message Errors
-4. Group Name Changes
-5. Participant Added / Removed / Left
-6. Chat Read Status Changes
-7. Typing Indicators
-8. BB Server Update
-9. BB Server URL Change
-10. Hello World (for testing)
+Every webhook uses the same outer envelope:
 
-You can also subscribe to an event that listens to all of the above at once.
+```json
+{
+  "type": "event-name",
+  "data": {}
+}
+```
 
-Simply provide a URL and the server will POST to it whenever your desired event occurs.
+* `type` is one of the event keys listed below.
+* `data` is the event-specific payload. It can be an object, string, or `null`, so receivers should branch on `type` before decoding it.
+
+### Payload examples
+
+A `new-message` event contains a serialized message. The exact fields can vary with the server version, macOS version, message type, and configured payload-size limits, but commonly include:
+
+```json
+{
+  "type": "new-message",
+  "data": {
+    "guid": "00000000-0000-0000-0000-000000000000",
+    "text": "Hello!",
+    "dateCreated": 1720000000000,
+    "isFromMe": false,
+    "attachments": [],
+    "chats": [
+      {
+        "guid": "iMessage;-;<address>"
+      }
+    ]
+  }
+}
+```
+
+A typing indicator has a smaller object payload:
+
+```json
+{
+  "type": "typing-indicator",
+  "data": {
+    "display": true,
+    "guid": "iMessage;-;<address>"
+  }
+}
+```
+
+Some events use a primitive value instead of an object. For example, `new-server` sends the updated server URL:
+
+```json
+{
+  "type": "new-server",
+  "data": "https://example.com"
+}
+```
+
+### Event keys
+
+| Event | Subscription key |
+| --- | --- |
+| All events | `*` |
+| New messages | `new-message` |
+| Message updates | `updated-message` |
+| Message send errors | `message-send-error` |
+| Group name changes | `group-name-change` |
+| Group icon changes | `group-icon-changed` |
+| Group icon removal | `group-icon-removed` |
+| Participant removed | `participant-removed` |
+| Participant added | `participant-added` |
+| Participant left | `participant-left` |
+| Chat read status changes | `chat-read-status-changed` |
+| Typing indicators | `typing-indicator` |
+| Scheduled message errors | `scheduled-message-error` |
+| Server updates | `server-update` |
+| New server URL | `new-server` |
+| Find My location updates | `new-findmy-location` |
+| WebSocket hello world | `hello-world` |
+| Incoming FaceTime call | `incoming-facetime` |
+| FaceTime call status changes (experimental) | `ft-call-status-changed` |
+| iMessage alias removed | `imessage-alias-removed` |
+| Theme backup created | `theme-backup-created` |
+| Theme backup updated | `theme-backup-updated` |
+| Theme backup deleted | `theme-backup-deleted` |
+| Settings backup created | `settings-backup-created` |
+| Settings backup updated | `settings-backup-updated` |
+| Settings backup deleted | `settings-backup-deleted` |
+
+Subscribe to `*` to receive every supported event. Otherwise, select only the event keys your receiver handles.
+
+Webhook delivery is best effort. The server does not retry a failed request, so the receiver should respond with a successful status promptly and queue longer-running work for later processing.


### PR DESCRIPTION
## Summary

- document the webhook HTTP method, content type, and stable `{ type, data }` envelope
- add representative payloads for message, typing-indicator, and primitive-value events
- replace the stale prose event list with every subscription key currently exposed by the server
- document wildcard subscriptions and best-effort, non-retried delivery
- link the server constant that is the source of truth for event keys

## Why

The existing page explains that BlueBubbles can send webhooks but does not show the request body a receiver must decode. It also lists only a subset of the events exposed by the server.

Fixes BlueBubblesApp/bluebubbles-server#797.

## Compatibility

The examples intentionally describe representative fields instead of promising one exhaustive `data` schema. Event data varies by event, server and macOS version, message type, and notification-size limits.

## Validation

- `git diff --check origin/master...HEAD` passes
- all 26 documented subscription keys match `webhookEventOptions` on current server `master` and `development`, in the same order
- all four JSON examples parse successfully
- the method, content type, envelope, wildcard behavior, and delivery wording match `WebhookService` and the inspected emitters
- a route-aware live test on the authorized SIP-custom host captured valid `display: true` and `display: false` typing events through the helper → server → HTTP webhook path

The live test sent no message or attachment, printed no personal identifier, and removed its temporary webhook and artifacts afterward.
