### PR TITLE
Secure manual Firestore setup rules

### DIFF
--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -56,6 +56,8 @@ service cloud.firestore {
 }
 ```
 
+The server's [`FCMService.setFirestoreRulesForApp`](https://github.com/BlueBubblesApp/bluebubbles-server/blob/development/packages/server/src/server/services/fcmService/index.ts#L154-L172) implementation is the source of truth for this policy. Compare this block with that implementation whenever either changes.
+
 This permits public reads only from the `server/config` document and public writes only to the `server/commands` document. Requests to unmatched paths are denied by default. The BlueBubbles server uses the Admin SDK with the service account generated below, so its database access bypasses these client security rules. The two listed operations remain public for BlueBubbles clients; this configuration limits their scope but does not add user authentication.
 
 7. Click the gear cog in the top left and click **Project Settings**.

--- a/server/installation-guides/manual-setup.md
+++ b/server/installation-guides/manual-setup.md
@@ -39,7 +39,25 @@ The name of the project does not have to be **BlueBubblesApp** if you already ha
 3. Next, **Create database** and press **Next > Enable.** You can change the database location if you are not based in North America so it is closer to you.
 4. If Cloud Firestore glitches and does not show you the database page, simply refresh the page.
 5. In the tabs near the top, click **Rules**
-6. Set the rule's condition from `allow read, write: if false;` to `allow read, write: if true;` (Change false to true) and click **Publish**.
+6. Replace the rules with the following configuration and click **Publish**:
+
+```text
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /server/config {
+      allow read;
+    }
+
+    match /server/commands {
+      allow write;
+    }
+  }
+}
+```
+
+This permits public reads only from the `server/config` document and public writes only to the `server/commands` document. Requests to unmatched paths are denied by default. The BlueBubbles server uses the Admin SDK with the service account generated below, so its database access bypasses these client security rules. The two listed operations remain public for BlueBubbles clients; this configuration limits their scope but does not add user authentication.
+
 7. Click the gear cog in the top left and click **Project Settings**.
 8. In the tabs near the top, navigate to **Service Accounts**. Generate a new private key and save this locally. **This will download file 1 / 2 needed for the manual setup.**
 9. Next, navigate to the **General** tab.


### PR DESCRIPTION
## Summary

- replace the manual setup's globally open Firestore rule with the scoped rules installed by the server's automatic Firebase setup
- allow unauthenticated reads only for `server/config` and unauthenticated writes only for `server/commands`
- explain default denial for unmatched paths, the service-account Admin SDK bypass, and the remaining public access boundary
- link the server implementation that is the source of truth for the policy and require maintainers to compare the two when either changes

## Why

The written manual setup currently instructs users to change Firebase's default rule to `allow read, write: if true;`. That exposes every Firestore document to unauthenticated reads and writes. The server's automatic setup already uses a narrower rule set, but the manual guide never adopted it.

## User impact

New manual-setup users will grant only the two client operations BlueBubbles needs instead of opening the entire database. Existing users can also replace their permissive rule with the documented rule. This limits exposure but does not authenticate the two public client operations.

## Coordination

PR #31 edits the database-creation steps on the same page for a separate issue. Merge simulations pass with #31 and #34 applied in either order, and the combined result preserves both changes.

## Validation

- `git diff --check origin/master...HEAD` passes
- the documented rules are byte-for-byte identical to `FCMService.setFirestoreRulesForApp` on current server `master` and `development`
- a local Firestore Emulator access matrix passed for the documented policy: public config read and commands write were allowed; the inverse operations and unmatched-path reads/writes were denied
- the old globally open rule no longer appears in this branch

The emulator test did not read or modify a production Firebase project. No production deployment was performed or required.

Fixes BlueBubblesApp/bluebubbles-server#783
