### PR TITLE
Update Docker-OSX Ventura bootstrap image

### DIFF
--- a/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
+++ b/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
@@ -62,10 +62,11 @@ docker run \
   -e WIDTH=1920 \
   -e HEIGHT=1080 \
   -e GENERATE_UNIQUE=true \
-  sickcodes/docker-osx:ventura
+  -e SHORTNAME=ventura \
+  sickcodes/docker-osx:latest
 ```
 
-This will take a while because it's downloading the image for Docker-OSX and generating a unique serial number and bootdisk for your mac VM.
+The `latest` Docker-OSX image supports multiple macOS versions, so `SHORTNAME=ventura` selects the version tested by this guide. This will take a while because it's downloading the image for Docker-OSX and generating a unique serial number and bootdisk for your mac VM.
 
 You may see a handful of errors particularly related to ALSA. These can be safely ignored.
 

--- a/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
+++ b/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
@@ -66,7 +66,7 @@ docker run \
   sickcodes/docker-osx:latest
 ```
 
-The mutable `latest` tag is intentional: Docker-OSX's [current Ventura example](https://github.com/sickcodes/Docker-OSX/blob/master/README.md#L103-L115) uses this image with `SHORTNAME=ventura`. If this command stops working, compare it with that upstream example. This guidance was last verified on July 27, 2026. The first run takes a while because it downloads the Docker-OSX image and generates a unique serial number and boot disk for your Mac VM.
+The mutable `latest` tag is intentional: Docker-OSX's [current Ventura example](https://github.com/sickcodes/Docker-OSX#ventura-13-) uses this image with `SHORTNAME=ventura`. If this command stops working, compare it with that upstream example. This guidance was last verified on July 27, 2026. The first run takes a while because it downloads the Docker-OSX image and generates a unique serial number and boot disk for your Mac VM.
 
 You may see a handful of errors particularly related to ALSA. These can be safely ignored.
 

--- a/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
+++ b/server/advanced/macos-virtualization/running-bluebubbles-in-docker-osx/README.md
@@ -66,7 +66,7 @@ docker run \
   sickcodes/docker-osx:latest
 ```
 
-The `latest` Docker-OSX image supports multiple macOS versions, so `SHORTNAME=ventura` selects the version tested by this guide. This will take a while because it's downloading the image for Docker-OSX and generating a unique serial number and bootdisk for your mac VM.
+The mutable `latest` tag is intentional: Docker-OSX's [current Ventura example](https://github.com/sickcodes/Docker-OSX/blob/master/README.md#L103-L115) uses this image with `SHORTNAME=ventura`. If this command stops working, compare it with that upstream example. This guidance was last verified on July 27, 2026. The first run takes a while because it downloads the Docker-OSX image and generates a unique serial number and boot disk for your Mac VM.
 
 You may see a handful of errors particularly related to ALSA. These can be safely ignored.
 


### PR DESCRIPTION
## Summary

- replace the unavailable `sickcodes/docker-osx:ventura` bootstrap image with `sickcodes/docker-osx:latest`
- set `SHORTNAME=ventura` so the multi-version image still installs the macOS version used by this guide
- explain that `latest` is intentionally mutable, link the upstream Ventura example, and record the verification date
- leave the later `naked` image workflow unchanged

## Why

Docker-OSX no longer publishes the `ventura` image tag used by the setup command. Its current setup flow uses the `latest` image and selects a macOS release with `SHORTNAME`.

## Decision

Keep `latest` to match Docker-OSX's maintained Ventura instructions. No digest is pinned because this PR does not have a KVM-tested digest; pinning a registry digest without booting it would imply reproducibility evidence we do not have. The guide now makes the mutable-tag tradeoff explicit and directs readers to the upstream command if it changes.

## Validation

- `git diff --check origin/master...HEAD` passes
- Docker Hub currently serves `sickcodes/docker-osx:latest`
- Docker Hub currently reports the removed `sickcodes/docker-osx:ventura` tag as not found
- the `SHORTNAME=ventura` and `latest` combination matches Docker-OSX's current Ventura example as of July 27, 2026
- the guide has no remaining `docker-osx:ventura` reference

## Limitation

The exact boot command was not exercised end to end because this machine is not a Linux host with KVM and `/dev/kvm`. The PR does not claim KVM execution.

Fixes #27
