### PR TITLE
Clarify the macOS requirement for container hosts

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -14,6 +14,12 @@ The server uses AppleScript to perform simple functions like sending messages & 
 
 Any macOS device running Sierra and newer, with iMessage activated successfully.
 
+### Why macOS is required
+
+BlueBubbles cannot run as an ordinary Linux or Windows container. The server relies on the macOS Messages app and its `chat.db` database, AppleScript, and, for optional Private API features, macOS-only frameworks, so it must run within macOS.
+
+A Linux host can still use Docker or Podman to run a macOS virtual machine. See the [macOS virtualization overview](advanced/macos-virtualization/) or the [Docker-OSX guide](advanced/macos-virtualization/running-bluebubbles-in-docker-osx/) for those setups. In both cases, BlueBubbles runs in the macOS guest rather than directly on the Linux host.
+
 {% hint style="info" %}
 macOS El Capitan is _no longer supported_
 {% endhint %}

--- a/server/README.md
+++ b/server/README.md
@@ -18,7 +18,7 @@ Any macOS device running Sierra and newer, with iMessage activated successfully.
 
 BlueBubbles cannot run as an ordinary Linux or Windows container. The server relies on the macOS Messages app and its `chat.db` database, AppleScript, and, for optional Private API features, macOS-only frameworks, so it must run within macOS.
 
-A Linux host can still use Docker or Podman to run a macOS virtual machine. See the [macOS virtualization overview](advanced/macos-virtualization/) or the [Docker-OSX guide](advanced/macos-virtualization/running-bluebubbles-in-docker-osx/) for those setups. In both cases, BlueBubbles runs in the macOS guest rather than directly on the Linux host.
+A Linux host can still use Docker or Podman as an advanced virtualization setup that runs a macOS virtual machine. See the [macOS virtualization overview](advanced/macos-virtualization/) or the [Docker-OSX guide](advanced/macos-virtualization/running-bluebubbles-in-docker-osx/) for those setups. In both cases, BlueBubbles runs in the macOS guest rather than directly on the Linux host, and iMessage must be activated and working inside that guest.
 
 {% hint style="info" %}
 macOS El Capitan is _no longer supported_


### PR DESCRIPTION
## What changed

- explain why the BlueBubbles server must run within macOS
- distinguish a native Linux or Windows container from a Linux-hosted macOS VM
- link readers to the existing virtualization and Docker-OSX guides

## Why

The server overview said that macOS virtual machines are compatible, but it did not explicitly answer whether BlueBubbles could run as an ordinary Linux or Windows container. That omission made Docker and Podman deployments sound platform-independent even though the server depends on the macOS Messages app, `chat.db`, AppleScript, and optional macOS-only Private API frameworks.

This clarification makes the deployment boundary explicit: Docker or Podman can host a macOS virtual machine, but BlueBubbles still runs inside the macOS guest.

## Impact

Readers can choose an appropriate host setup without mistaking the Docker-OSX path for a native Linux server.

## Checks

- `git diff --check`
- verified both linked documentation targets exist in the repository
- checked the wording against the maintainer explanation on the issue

Fixes BlueBubblesApp/bluebubbles-server#762
